### PR TITLE
Add distance from last to 1st waypoints to fitness

### DIFF
--- a/optimal-road-trip/Computing the optimal road trip across the U.S..ipynb
+++ b/optimal-road-trip/Computing the optimal road trip across the U.S..ipynb
@@ -301,6 +301,7 @@
       "        waypoint1 = solution[index - 1]\n",
       "        waypoint2 = solution[index]\n",
       "        solution_fitness += waypoint_distances[frozenset([waypoint1, waypoint2])]\n",
+      "	   solution_fitness += waypoint_distances[frozenset([solution[len(solution)-1], solution[0]])]\n",
       "        \n",
       "    return solution_fitness\n",
       "\n",

--- a/optimal-road-trip/OptimalRoadTripHtmlSaveAndDisplay.py
+++ b/optimal-road-trip/OptimalRoadTripHtmlSaveAndDisplay.py
@@ -146,7 +146,8 @@ def compute_fitness(solution):
         waypoint1 = solution[index - 1]
         waypoint2 = solution[index]
         solution_fitness += waypoint_distances[frozenset([waypoint1, waypoint2])]
-        
+    # Adds distance from last to first waypoints to close tour
+    solution_fitness += waypoint_distances[frozenset([solution[len(solution)-1], solution[0]])]  
     return solution_fitness
 
 def generate_random_agent():


### PR DESCRIPTION
The generated map shows a complete tour of the waypoints, but the GA calculates fitness based on the sum of distances from waypoint 1 to waypoint 2, ...., waypoint (end-1) to waypoint(end). It needs to add in the distance from waypoint(end) to waypoint(1) to minimize total roadtrip tour distance. It probably didn't make a difference in most of the final maps generated but possibly could. I added the change to the fitness formula in the python file and ipython file. Great project, that we used in a hackathon for visiting all bike to work treat stations and also local breweries by bike. 